### PR TITLE
Add end to end test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+/dummy_data
+/scripts
+/.Scratch

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/disk-hog-backup.iml
+++ b/.idea/disk-hog-backup.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="EMPTY_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/disk-hog-backup.iml" filepath="$PROJECT_DIR$/.idea/disk-hog-backup.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "bitflags"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,7 +178,24 @@ dependencies = [
  "chrono",
  "clap",
  "rand",
+ "tempfile",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "getrandom"
@@ -182,7 +205,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -235,6 +270,12 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
@@ -311,7 +352,20 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -338,6 +392,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom 0.3.1",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +422,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -490,6 +567,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 chrono = "0.4.39"
 clap = { version = "4.5.23", features = ["derive"] }
 rand = "0.8.5"
+tempfile = "3.2"

--- a/src/dhcopy/copy_file.rs
+++ b/src/dhcopy/copy_file.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{self};
+use std::io::{self, Write};
 use std::path::Path;
 use crate::test_helpers::test_helpers::{create_tmp_folder, file_contents_matches};
 

--- a/src/dhcopy/copy_file.rs
+++ b/src/dhcopy/copy_file.rs
@@ -1,7 +1,7 @@
-use crate::test_helpers::test_helpers::{create_tmp_folder, file_contents_matches};
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self};
 use std::path::Path;
+use crate::test_helpers::test_helpers::{create_tmp_folder, file_contents_matches};
 
 const THE_FILE: &str = "testfile.txt";
 const THE_TEXT: &str = "backmeup susie";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod backup;
+mod backup_sets {
+    pub mod set_namer;
+    pub mod backup_set;
+}
+pub mod dhcopy;
+pub mod test_helpers;

--- a/tests/backup_e2e.rs
+++ b/tests/backup_e2e.rs
@@ -1,0 +1,24 @@
+mod common;
+
+use common::{create_test_folder, compare_files};
+use std::process::Command;
+use std::path::Path;
+
+#[test]
+fn test_backup_via_cli() -> Result<(), Box<dyn std::error::Error>> {
+    let source_dir = create_test_folder();
+    let dest_dir = create_test_folder();
+    
+    // Run backup command
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            "--source", source_dir.path().to_str().unwrap(),
+            "--destination", dest_dir.path().to_str().unwrap()
+        ])
+        .status()?;
+
+    assert!(status.success());
+    Ok(())
+}

--- a/tests/backup_e2e.rs
+++ b/tests/backup_e2e.rs
@@ -1,19 +1,22 @@
-mod common;
+// This is an integration test file that lives in the tests/ directory
+// Integration tests verify that multiple components work together correctly
+mod common;  // Helper module for shared test utilities
 
-use common::{create_test_folder, compare_files};
-use std::process::Command;
-use std::path::Path;
+use common::{create_test_folder};  // Import test utilities
+use std::process::Command;  // For executing CLI commands
 
 #[test]
 fn test_backup_via_cli() -> Result<(), Box<dyn std::error::Error>> {
+    // Create temporary test directories using helper from common/mod.rs
     let source_dir = create_test_folder();
     let dest_dir = create_test_folder();
     
-    // Run backup command
+    // Test the CLI by actually running the binary with cargo run
+    // This tests the full application stack from CLI to core logic
     let status = Command::new("cargo")
         .args([
             "run",
-            "--",
+            "--",  // Arguments after -- are passed to our program
             "--source", source_dir.path().to_str().unwrap(),
             "--destination", dest_dir.path().to_str().unwrap()
         ])

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,13 +1,18 @@
-use std::path::Path;
-use std::fs;
-use tempfile::TempDir;
+// Key imports
+use std::path::Path;         // For path manipulation
+use std::fs;                 // File system operations
+use tempfile::TempDir;       // For temporary test directories
 
+// Creates temporary test directory that auto-cleans up
 pub fn create_test_folder() -> TempDir {
-    TempDir::new().unwrap()
+    TempDir::new().unwrap()  // Creates and returns temp directory
 }
 
+// Compares contents of two files
 pub fn compare_files(file1: &Path, file2: &Path) -> bool {
+    // Read both files to strings
     let content1 = fs::read_to_string(file1).unwrap();
     let content2 = fs::read_to_string(file2).unwrap();
+    // Compare contents
     content1 == content2
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,13 @@
+use std::path::Path;
+use std::fs;
+use tempfile::TempDir;
+
+pub fn create_test_folder() -> TempDir {
+    TempDir::new().unwrap()
+}
+
+pub fn compare_files(file1: &Path, file2: &Path) -> bool {
+    let content1 = fs::read_to_string(file1).unwrap();
+    let content2 = fs::read_to_string(file2).unwrap();
+    content1 == content2
+}


### PR DESCRIPTION
https://github.com/timabell/disk-hog-backup/issues/10
" Set up a test folder
Execute a backup via the cli
Verify tree structure and contents on target folder match"

- Add directory "tests" with common/mod.rs for shared test utilities.
- Add backup_e2e minimal end to end test
- Add lib.rs (main library entry point) to define module structure and visibility so that the backup functions are public and usable by both the CLI interface in main.rs and the unit tests in module directories

```
lib.rs
├── backup/            (public)
├── backup_sets/       (private)
│   ├── set_namer     (public)
│   └── backup_set    (public)
├── dhcopy/           (public)
└── test_helpers/     (public)
```
Note: All tests are passing, other warnings to be resolved in next commit
